### PR TITLE
Fix installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Add [Typechain](https://www.github.com/ethereum-ts/TypeChain) tasks to your Buid
 ## Installation
 
 ```bash
-npm i buidler-typechain typechain ts-generator typechain-target-ethers typechain-target-truffle typechain-target-web3-v1
+npm i buidler-typechain "typechain@^1.0.0" ts-generator "typechain-target-ethers@^1.0.0-beta.2" typechain-target-truffle typechain-target-web3-v1
 ```
 
 And add the following statement to your `buidler.config.js`:


### PR DESCRIPTION
Hey @rhlsthrm 

I added explicit versions to some of the packages from the installation instructions. Without them, TypeChain 2 was installed, and this plugin is built for TypeChain 1.