### PR TITLE
Add missing 'runOnCompile: boolean' option to type definitions

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -1,9 +1,11 @@
 export interface TypechainUserConfig {
   outDir?: string;
   target?: "ethers-v5" | "web3-v1" | "truffle-v5";
+  runOnCompile?: boolean;
 }
 
 export interface TypechainConfig {
   outDir: string;
   target: "ethers-v5" | "web3-v1" | "truffle-v5";
+  runOnCompile: boolean;
 }


### PR DESCRIPTION
as this is only a two-line change, I created this quick PR

fixes #9 