### PR TITLE
Accept underscores in contract names

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -51,7 +51,7 @@ task(TASK_COMPILE, "Compiles the entire project, building all artifacts")
         new TypeChain({
           cwd,
           rawConfig: {
-            files: `${config.paths.artifacts}/!(build-info)/**/+([a-zA-Z0-9]).json`,
+            files: `${config.paths.artifacts}/!(build-info)/**/+([a-zA-Z0-9_]).json`,
             outDir: typechain.outDir,
             target: typechain.target,
           },


### PR DESCRIPTION
We're using underscores in our contract names over at https://github.com/ethereum-optimism/contracts/. Pattern matching here will only accept alphanumeric contract names, but underscores are valid.